### PR TITLE
Translate Part 0 to English and add English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
     <h1>zero-to-sglang</h1>
     <h3>📚 《从零手搓SGLang》</h3>
     <p><em>A hands-on Chinese tutorial on LLM inference: build a mini-sglang from scratch, then read the real SGLang source.</em></p>
+    <p><strong>简体中文</strong> | <a href="./README_en.md">English</a></p>
 </div>
 
 <div align="center">
   <img src="https://img.shields.io/github/stars/datawhalechina/zero-to-sglang?style=flat&logo=github" alt="GitHub stars"/>
   <img src="https://img.shields.io/github/forks/datawhalechina/zero-to-sglang?style=flat&logo=github" alt="GitHub forks"/>
-  <img src="https://img.shields.io/badge/language-Chinese-brightgreen?style=flat" alt="Language"/>
+  <img src="https://img.shields.io/badge/language-Chinese%20%7C%20English-brightgreen?style=flat" alt="Language"/>
   <a href="https://github.com/datawhalechina/zero-to-sglang"><img src="https://img.shields.io/badge/GitHub-Project-blue?style=flat&logo=github" alt="GitHub Project"></a>
   <a href="https://datawhalechina.github.io/zero-to-sglang/"><img src="https://img.shields.io/badge/在线阅读-Online%20Reading-green?style=flat&logo=gitbook" alt="Online Reading"></a>
 </div>
@@ -131,9 +132,11 @@ zero-to-sglang/
 │   ├── community/           # 社区贡献专区：手搓记录、踩坑、学习笔记
 │   └── WRITING_TEMPLATE.md  # 中文课程写作模板
 ├── eng/                     # English edition（在线阅读 /eng/，翻译中）
+│   ├── part0/               # Part 0: Before you learn
 │   └── WRITING_TEMPLATE.md  # 英文课程写作模板
 ├── docs/.vitepress/         # VitePress 站点配置
-├── README.md                # 项目说明
+├── README.md                # 项目说明（中文）
+├── README_en.md             # 项目说明（English）
 └── .gitignore               # Git 忽略配置
 ```
 
@@ -147,6 +150,7 @@ zero-to-sglang/
 
 - 🐛 发现内容、公式、代码有错：提 Issue，或者直接改了提 PR
 - 📝 补充章节内容、优化表述：提 PR。章节划分和编号按[写作模板](ch/WRITING_TEMPLATE.md)里的大纲来，不要自行增删、合并章节
+- 🌐 参与翻译：按[英文写作模板](eng/WRITING_TEMPLATE.md)把章节翻译成英文，放在 `eng/` 下
 - 💡 对课程有想法：开 Issue 讨论
 
 <strong>2. 分享你的实践</strong>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <h1>zero-to-sglang</h1>
     <h3>📚 《从零手搓SGLang》</h3>
     <p><em>A hands-on Chinese tutorial on LLM inference: build a mini-sglang from scratch, then read the real SGLang source.</em></p>
-    <p><strong>简体中文</strong> | <a href="./README_en.md">English</a></p>
+    <p>其他语言：<a href="./README_en.md">English</a></p>
 </div>
 
 <div align="center">

--- a/README_en.md
+++ b/README_en.md
@@ -1,0 +1,253 @@
+<div align='center'>
+    <img src="./ch/images/zero_to_sglang.png" alt="zero-to-sglang banner" width="100%">
+    <h1>zero-to-sglang</h1>
+    <h3>📚 Build SGLang from Scratch</h3>
+    <p><em>A hands-on tutorial on LLM inference: build a mini-sglang from scratch, then read the real SGLang source.</em></p>
+    <p><a href="./README.md">简体中文</a> | <strong>English</strong></p>
+</div>
+
+<div align="center">
+  <img src="https://img.shields.io/github/stars/datawhalechina/zero-to-sglang?style=flat&logo=github" alt="GitHub stars"/>
+  <img src="https://img.shields.io/github/forks/datawhalechina/zero-to-sglang?style=flat&logo=github" alt="GitHub forks"/>
+  <img src="https://img.shields.io/badge/language-Chinese%20%7C%20English-brightgreen?style=flat" alt="Language"/>
+  <a href="https://github.com/datawhalechina/zero-to-sglang"><img src="https://img.shields.io/badge/GitHub-Project-blue?style=flat&logo=github" alt="GitHub Project"></a>
+  <a href="https://datawhalechina.github.io/zero-to-sglang/eng/"><img src="https://img.shields.io/badge/Read-Online-green?style=flat&logo=gitbook" alt="Online Reading"></a>
+</div>
+
+<div align="center">
+  <p><em>Start from what inference really is, build a mini-sglang by hand, then read the real SGLang source</em></p>
+  <p>Datawhale × RadixArk</p>
+</div>
+
+---
+
+> **Translation status**: the English edition is translated from the Chinese original part by part. Part 0 is available; the rest is in progress. Chapters that are not translated yet link to the Chinese original and are marked (zh). Want to help? See [Contributing](#-contributing).
+
+## 🎯 About
+
+&emsp;&emsp;Large models have moved on from the training race to the inference race. Once applications took off, inference cost and latency became the real bottleneck: on the same GPU, a good inference engine can serve several times more requests. Yet there are few tutorials on inference engines. They either stay at the concept level without touching code, or drop you straight into the SGLang source with no idea where to start.
+
+&emsp;&emsp;This course fills that gap. The first half starts from the core questions of inference: why KV Cache exists, how prefill differs from decode, what compute-bound and memory-bound actually mean. The middle part walks you through building a mini-sglang from scratch: forward pass, generation, KV Cache, HTTP serving, Continuous Batching, Paged KV Cache, RadixAttention, added one at a time. The last part returns to the real SGLang, explains how its cutting-edge optimizations are actually implemented, and finally shows you how to land your first solid PR in SGLang.
+
+&emsp;&emsp;The project is jointly launched by <strong>Datawhale</strong> and <strong>RadixArk</strong> (the company founded by the SGLang team). SGLang is technically solid and actively iterated in the inference framework space. If you like this project, please give the [official SGLang repository](https://github.com/sgl-project/sglang) a ⭐.
+
+## ✨ What you will learn
+
+- 📖 <strong>Understand inference</strong>: KV Cache, prefill/decode, compute-bound vs. memory-bound, and what these concepts actually mean
+- 🏗️ <strong>Build the engine</strong>: write a mini-sglang from 0 to 1, with every step landing in code
+- 🛠️ <strong>Read the real engine</strong>: how RadixAttention, Paged KV Cache and Continuous Batching are implemented inside SGLang
+- ⚙️ <strong>Touch the frontier</strong>: quantization, hierarchical caching, DP Attention / EP / PP, Prefill-Decode disaggregation
+- 🚀 <strong>Join open source</strong>: learn profiling and trace analysis, and walk through the full SGLang PR workflow
+
+## 📋 Prerequisites
+
+- **Python**: fluent in Python, with basic software engineering habits
+- **Deep learning basics**: familiar with PyTorch and the fundamentals of neural networks
+- **Math**: linear algebra and probability; knowing roughly how matrix multiplication and attention are computed is enough
+- **GPU programming (optional)**: knowing CUDA basics helps, but is not required. Part I fills in the gaps from scratch
+- **Hardware (optional)**: Part I needs no GPU; most of Part II can be debugged on CPU, but the full implementation and performance tests are best done on a GPU (cloud is fine)
+
+## 🔗 Links
+
+- **Repository**: https://github.com/datawhalechina/zero-to-sglang
+- **SGLang**: https://github.com/sgl-project/sglang
+- **mini-sglang reference implementation**: https://github.com/sgl-project/mini-sglang
+
+## 📖 Syllabus
+
+> Status legend: ✅ Done  🔄 In progress  📝 Needs polish  🚧 Planned  ⏸️ Paused
+>
+> Chapters in **bold** are written by SGLang core members. Links marked (zh) point to the Chinese original, not yet translated.
+
+| Chapter | Key content | Status |
+|------|----------|------|
+| <strong>Part 0 — Before you learn</strong> | | |
+| [0.1 Coding Ethics and Open-Source Spirit](eng/part0/Part0-Coding-Ethics-and-Open-Source-Spirit.md) | Own your code, communicate like a human, profile first, the open-source spirit | ✅ |
+| [0.2 Deploy Your First SGLang Server](eng/part0/Part0-Deploy-Your-First-SGLang-Server.md) | Environment setup; run Qwen3-0.6B with SGLang on your own GPU | ✅ |
+| <strong>Part I — Foundations (concepts only, no code, no GPU)</strong> | | |
+| [1. Introduction to LLM (zh)](ch/part1/第1章_LLM入门.md) | What an LLM is and how it evolved, the Transformer architecture, autoregressive generation, key concepts | ✅ |
+| [2. Introduction to inference (zh)](ch/part1/第2章_推理入门.md) | Training vs. inference, prefill/decode, compute-bound vs. memory-bound, the Roofline model | ✅ |
+| 3. Introduction to GPU | GPU architecture basics, how LLM inference executes on a GPU, understanding inference bottlenecks from the hardware | 🔄 |
+| [4. KV Cache: The Core Data Structure of Inference (zh)](ch/part1/第4章_推理的核心数据结构入门.md) | Deriving KV Cache from attention, cache lifecycle, quantitative memory analysis | ✅ |
+| [5. Introduction to Benchmark (zh)](ch/part1/第5章_Benchmark入门.md) | Core metrics such as TTFT / TPOT / ITL / Goodput, percentiles and tail latency, how to design, run and read a benchmark | 🔄 |
+| <strong>Part II — Build Your Own Mini SGL</strong> | | |
+| 1. mini-sglang: what an inference engine looks like | Overall architecture of an inference engine, module breakdown, roadmap for this part | 📝 |
+| 2. **Inside SGLang: The Path of a Request** | The full lifecycle of a request from arrival to response | 🚧 |
+| 3. Your First 200 Lines: Forward Pass and Generation | Hand-writing the forward pass and the autoregressive generation loop | 🚧 |
+| 4. KV Cache: From O(n²) to O(n) | Implementing the cache and optimizing attention computation | 🚧 |
+| 5. Serving It: HTTP and Concurrent Requests | HTTP serving and handling concurrent requests | 🚧 |
+| 6. Continuous Batching and the Scheduler | Continuous batching and scheduler design | 🚧 |
+| 7. Paged KV Cache and Memory Management | Paged KV Cache and GPU memory management | 🚧 |
+| 8. RadixAttention and Prefix Caching | RadixAttention and prefix caching | 🚧 |
+| 9. Multi-process & Tensor Parallelism | Multi-process execution and tensor parallelism | 🚧 |
+| 10. Speculative Decoding | Speculative decoding | 🚧 |
+| <strong>Part III — Advanced Inference Technique (deep into the real SGLang)</strong> | | |
+| 1. **Attention Backends (FlashInfer / Triton / FA3 / FlashMLA) and CUDA Graph** | Comparing mainstream attention backends, and CUDA Graph | 🚧 |
+| 2. **Quantization and Low-Precision Inference** | Quantization and low-precision inference | 🚧 |
+| 3. **Hierarchical Caching** | Hierarchical caching | 🚧 |
+| 4. **Scaling Out: DP Attention, EP, PP** | Scaling out: DP Attention / EP / PP | 🚧 |
+| 5. **Prefill-Decode Disaggregation** | Prefill-Decode disaggregation | 🚧 |
+| <strong>Part IV — How to Make Contribution to SGLang (optional)</strong> | | |
+| 1. **Deploying SGLang with the Cookbook** | Deploying SGLang with the Cookbook | 🚧 |
+| 2. **Measuring It All: Profiling and Trace Analysis** | Profiling and trace analysis | 🚧 |
+| 3. **SGLang PR Workflow** | The full SGLang PR workflow | 🚧 |
+
+## 🗓️ Writing schedule
+
+Start date: Monday, August 24, 2026. About one week per chapter; chapters in bold are written by SGLang core members.
+
+| Part | Schedule | Status |
+|------|----------|------|
+| Part 0 — Before you learn | Done | ✅ |
+| Part I — Foundations | Writing 8.24 ~ 9.06, review 9.07 ~ 9.13 | 🔄 |
+| Part II — Build Your Own Mini SGL | Writing 9.14 ~ 10.04, review 10.05 ~ 10.10 | 🚧 |
+| Part III — Advanced Inference Technique | 10.10 ~ 11.15 | 🚧 |
+| Part IV — How to Make Contribution to SGLang | 11.16 ~ 12.6 | 🚧 |
+
+## 🚀 Quick start
+
+```bash
+# Clone the repository
+git clone https://github.com/datawhalechina/zero-to-sglang.git
+cd zero-to-sglang
+# Install dependencies as each chapter requires
+```
+
+### Learning path
+
+1️⃣ Read Part I to build an overall picture of inference (no GPU needed)  
+2️⃣ Follow Part II to build a mini-sglang from 0 to 1  
+3️⃣ Move to Part III and understand the frontier optimizations against the real SGLang source  
+4️⃣ Finish Part IV: profiling, trace analysis, and the full PR workflow
+
+### Project structure
+
+```
+zero-to-sglang/
+├── ch/                      # Chinese edition (read online at /ch/)
+│   ├── part0/               # Part 0: Before you learn
+│   ├── part1/               # Part I: Foundations (in progress)
+│   ├── part2/               # Part II: Build Your Own Mini SGL (planned)
+│   ├── part3/               # Part III: Advanced Inference Technique (planned)
+│   ├── part4/               # Part IV: How to Make Contribution to SGLang (planned)
+│   ├── community/           # Community corner: build logs, pitfalls, study notes
+│   └── WRITING_TEMPLATE.md  # Writing template for the Chinese edition
+├── eng/                     # English edition (read online at /eng/, in progress)
+│   ├── part0/               # Part 0: Before you learn
+│   └── WRITING_TEMPLATE.md  # Writing template for the English edition
+├── docs/.vitepress/         # VitePress site config
+├── README.md                # Project overview (Chinese)
+├── README_en.md             # Project overview (English)
+└── .gitignore               # Git ignore rules
+```
+
+## 🤝 Contributing
+
+We are an open community and welcome contributions of every kind. Before you start, please read [Part 0](eng/part0/Part0-Coding-Ethics-and-Open-Source-Spirit.md) to understand the coding ethics and open-source spirit we expect.
+
+<strong>1. Improve the course text</strong>
+
+- 🐛 Found an error in the content, a formula, or code: open an issue, or fix it and open a PR
+- 📝 Add to a chapter or improve the wording: open a PR. Chapter division and numbering follow the outline in the [writing template](eng/WRITING_TEMPLATE.md); do not add, remove, or merge chapters on your own
+- 🌐 Translate: help translate chapters into English following the [English writing template](eng/WRITING_TEMPLATE.md), and put them under `eng/`
+- 💡 Have ideas about the course: open an issue to discuss
+
+<strong>2. Share your practice</strong>
+
+- 🔧 Built mini-sglang yourself following Part II? Write down the bugs you hit and how you fixed them
+- ⚠️ Pitfalls from deploying SGLang or setting up the environment, or places where the docs were unclear and others deserve a warning
+- 📒 Study notes written in your own words after finishing a chapter, or extra derivations and experiments
+
+Community content currently lives under the matching directory in `ch/community/`.
+
+<strong>How to open a PR</strong>
+
+1. Fork the repository and create a branch from `main`
+2. PR requirements are in [ch/community/PR_requirement.md](ch/community/PR_requirement.md) (zh); check every item before submitting
+
+## ❓ FAQ
+
+<details>
+<summary><b>Q: Can I follow the course without a GPU?</b></summary>
+
+Yes. Part I involves no GPU at all. Most of the code in Part II can be debugged on CPU, but full performance verification and the deeper content of Part III are best done on a GPU (cloud is fine).
+</details>
+
+<details>
+<summary><b>Q: Do I need to master CUDA first?</b></summary>
+
+No. The course starts from inference concepts. Low-level topics such as attention backends only come in Part III, and you can catch up on CUDA as needed at that point.
+</details>
+
+
+## 💬 Reader group
+
+Join the zero-to-sglang reader group (WeChat) to learn together and get your questions answered:
+
+<div align="center">
+  <table>
+    <tr>
+      <td align="center"><img src="./ch/images/zero-to-sglang读者交流群.jpg" alt="Reader group" width="280"><br>Reader group</td>
+    </tr>
+  </table>
+</div>
+
+
+
+## 👥 Contributors
+
+
+*We thank every developer who has contributed to this project!*
+
+
+### Special thanks
+
+- Thanks to Datawhale and the SGLang team for supporting the project
+  - Datawhale: [@1iyouzhen](https://github.com/1iyouzhen), [@xuhu0115](https://github.com/xuhu0115), [@kangkang-Adam](https://github.com/kangkang-Adam)
+  - SGLang: [@Ccyest](https://github.com/Ccyest), [@fcranzhou](https://github.com/fcranzhou)
+- Thanks to [@Sm1les](https://github.com/Sm1les) for the help and support
+- Thanks to every developer who has contributed to this project ❤️
+
+## 🎓 Citation
+
+If zero-to-sglang helps your research or work, please cite it:
+
+```bibtex
+@misc{zero_to_sglang2026,
+  title  = {zero-to-sglang: Building an LLM Inference Engine from Scratch},
+  author = {TODO},
+  year   = {2026},
+  url    = {https://github.com/datawhalechina/zero-to-sglang},
+  note   = {GitHub repository}
+}
+```
+
+<!-- TODO: fill in the author list -->
+
+## ⭐ Star History
+
+If this project helps you, please give it a Star ⭐️!
+
+<!-- TODO: enable the Star History chart after deployment -->
+<!--
+<a href="https://www.star-history.com/?repos=datawhalechina%2Fzero-to-sglang&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=datawhalechina/zero-to-sglang&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=datawhalechina/zero-to-sglang&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=datawhalechina/zero-to-sglang&type=date&legend=top-left" />
+ </picture>
+</a>
+-->
+
+## 📄 License
+
+<a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-lightgrey" /></a>
+
+This work is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/).
+
+---
+
+<div align="center">
+  <p>Helping more people learn to build LLM inference engines, systematically</p>
+  <p>Made with ❤️ by Datawhale & RadixArk</p>
+</div>

--- a/README_en.md
+++ b/README_en.md
@@ -3,7 +3,7 @@
     <h1>zero-to-sglang</h1>
     <h3>📚 Build SGLang from Scratch</h3>
     <p><em>A hands-on tutorial on LLM inference: build a mini-sglang from scratch, then read the real SGLang source.</em></p>
-    <p><a href="./README.md">简体中文</a> | <strong>English</strong></p>
+    <p>Also available in: <a href="./README.md">简体中文</a></p>
 </div>
 
 <div align="center">
@@ -178,20 +178,6 @@ Yes. Part I involves no GPU at all. Most of the code in Part II can be debugged 
 
 No. The course starts from inference concepts. Low-level topics such as attention backends only come in Part III, and you can catch up on CUDA as needed at that point.
 </details>
-
-
-## 💬 Reader group
-
-Join the zero-to-sglang reader group (WeChat) to learn together and get your questions answered:
-
-<div align="center">
-  <table>
-    <tr>
-      <td align="center"><img src="./ch/images/zero-to-sglang读者交流群.jpg" alt="Reader group" width="280"><br>Reader group</td>
-    </tr>
-  </table>
-</div>
-
 
 
 ## 👥 Contributors

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -85,10 +85,19 @@ const chSidebar: DefaultTheme.SidebarItem[] = [
 
 const engNav: DefaultTheme.NavItem[] = [
   { text: 'Home', link: '/eng/' },
+  { text: 'Part 0', link: '/eng/part0/Part0-Coding-Ethics-and-Open-Source-Spirit' },
 ]
 
 // Sections are added here as their English chapters land.
-const engSidebar: DefaultTheme.SidebarItem[] = []
+const engSidebar: DefaultTheme.SidebarItem[] = [
+  {
+    text: 'Part 0 — Before you learn',
+    items: [
+      { text: 'Coding Ethics and Open-Source Spirit', link: '/eng/part0/Part0-Coding-Ethics-and-Open-Source-Spirit' },
+      { text: 'Deploy Your First SGLang Server', link: '/eng/part0/Part0-Deploy-Your-First-SGLang-Server' },
+    ],
+  },
+]
 
 // ---------------------------------------------------------------------------
 // Site

--- a/eng/index.md
+++ b/eng/index.md
@@ -7,7 +7,10 @@ hero:
   tagline: "Start from what inference really is, build a mini-sglang by hand, then read the real SGLang source"
   actions:
     - theme: brand
-      text: Read the Chinese edition
+      text: Start Learning
+      link: /eng/part0/Part0-Coding-Ethics-and-Open-Source-Spirit
+    - theme: alt
+      text: 简体中文
       link: /ch/
     - theme: alt
       text: View on GitHub
@@ -26,6 +29,6 @@ features:
 
 ## English edition
 
-The English edition is being translated from the Chinese original, part by part. Part 0 comes first. Until a chapter lands here, the [Chinese edition](/ch/) is the complete reference.
+The English edition is being translated from the Chinese original, part by part. Part 0 is available now and more parts are on the way. Until a chapter lands here, the [Chinese edition](/ch/) is the complete reference.
 
 Want to help translate? See the [writing template](https://github.com/datawhalechina/zero-to-sglang/blob/main/eng/WRITING_TEMPLATE.md) and open a PR.

--- a/eng/part0/Part0-Coding-Ethics-and-Open-Source-Spirit.md
+++ b/eng/part0/Part0-Coding-Ethics-and-Open-Source-Spirit.md
@@ -1,0 +1,84 @@
+# Part 0 — Before you learn
+
+## 0.1 Coding ethics and open-source spirit
+
+Welcome to zero-to-sglang. This first lesson is not about technology. There is an old saying that character comes before craft, and before we teach you anything technical we want to pass on a healthy open-source spirit, and show how to communicate and collaborate with others in an open-source community. In the AI era, writing code has become far easier than reviewing it, so we hope every open-source contributor takes responsibility for their own code, respects the craft, and respects every reviewer's time.
+
+What follows may look like common sense. But every point here comes from real cases we ran into while maintaining open-source communities, so we are spelling them out in the hope that they become second nature.
+
+---
+
+## Coding ethics
+
+### 1. Take responsibility for your own code
+
+First, to be clear: the open-source community is not against writing code with AI. Every programmer does it. But for anything headed to production, we expect that the author has carefully read the code they submit and knows why it is written the way it is.
+
+Code adapted from Stack Overflow the old-fashioned way, code written by AI, code typed by hand: all of it is legitimate. What has changed in the AI era is the cost. 500 lines used to take an hour, sometimes an afternoon; now it takes 30 seconds. But a reviewer still needs a lot of time to read those 500 lines and decide whether they are correct. This is an invisible transfer of workload and responsibility, and it is exactly why every contributor needs the self-discipline to own their code. Otherwise the project cannot keep going.
+
+So before opening a PR, ask yourself a few questions:
+
+- What problem does this PR solve? Is there a clear motivation?
+- What does this PR deliver, and how can someone reproduce the result?
+- Which code regions and components does it touch? What is the call flow? How invasive is it?
+- Pick any function in the diff at random: can I say what would happen if it were deleted?
+
+If you cannot answer any one of these, do not submit yet. Keep PRs from growing too large and make sure you fully understand them. That lowers the reviewer's cost, and the cost of the back-and-forth that follows, which brings us to the second point.
+
+### 2. Communicate like a human
+
+Issues, PR descriptions, review replies, chat in the group: write them in your own words. Do not paste AI replies wholesale.
+
+The reason is the same as above: respect other people's time. Everyone can spot an AI-generated reply by now. In two hundred words there may be fifteen words of actual information; the rest is AI packaging.
+
+A typical example:
+
+> Thank you for your review! The point you raised is very valuable. Regarding whether to enable CUDA Graph, I have conducted an in-depth analysis. 1. Performance: CUDA Graph can effectively reduce the CPU overhead of kernel launches, with significant gains in small-batch scenarios... 2. Memory: the additional memory consumed by graph capture needs to be considered... I ran experiments, and the results are roughly... In summary, if the goal is peak performance, I recommend enabling CUDA Graph; if the goal is minimal memory, I recommend disabling it. I believe the current implementation is a reasonable trade-off. I look forward to your further guidance...
+
+> Tried it. With CUDA Graph on, the decode step at batch=n drops from xx ms to xx ms; profiles from before and after are attached below. Graph capture costs an extra yy of memory.
+
+The second is short and clear; you know what it says at a glance. The first is classic AI slop, generated on the spot, and it inspires very little confidence.
+
+Worse, when a maintainer sees an AI-flavored reply, the first thought is "this PR was probably generated too, and the author never read it." That directly damages the trust others place in your code.
+
+### 3. Profile first, always
+
+Profiling is always the first step of any performance work.
+
+The right order is: profile, find the bottleneck, change it, profile again, compare. We want to avoid shooting the arrow first and painting the target around it. Landing an optimization and merging it into the repo is not the end of the story. In open-source practice many people make the same mistake: the part they set out to optimize accounts for maybe 3% of total time. Optimize a 3% piece down to zero and the end-to-end result is only 3% faster.
+
+So before you start, answer one question: how much time does the code I am about to change take under a real workload? If you do not know, go measure it. That one hour can save you two weeks.
+
+This is also why we say: do not chase merged PRs just to pad your project experience. The more people approach it that way, the more junk PRs like the ones described above pile up, and the good PRs drown among them.
+
+We therefore ask that a performance PR include at least these three things:
+
+1. **Before-and-after numbers.**
+2. **A reproducible command.**
+3. **Profiling evidence.** What people want to see is not "12% faster" but "why it is faster." Use a profiler, plot the timeline, learn to read and explain it, and make sure the PR actually solves the problem stated in the motivation.
+
+### 4. Summary: what kind of first PR is unwelcome
+
+Pulling the discussion together, here are the common pitfalls of a bad PR. Please check yourself against them before submitting:
+
+1. A large AI-generated PR the author has not read. Thousands of lines, and questions about any part of it go unanswered.
+2. A performance PR with no data and no reproducible results.
+3. A refactor of core modules without design work, far too invasive.
+4. Design decisions made without discussion: adding a new dependency, introducing a new abstraction, changing default parameters.
+5. Ten spam PRs opened at once, none with a clear motivation.
+
+So what does a good first PR look like? Small, complete, solving a real existing issue, with verification. Our usual advice: understand first, then ask, then contribute. A good PR author is, first of all, someone who can find a problem in the system and file an issue about it.
+
+---
+
+## Open-source spirit
+
+### One for all, all for one
+
+Everything this course relies on, PyTorch, FlashAttention, SGLang, the open weights you download, and this course itself, is open source. In other words, someone gave it to you for free. So the default mindset in open source is simple: you benefit from what others left behind, so leave your own work behind too, and keep the cycle turning. Concretely, for this course: you will probably hit plenty of pitfalls while building mini-sglang later, and your deployment environment will have problems. Spend ten minutes writing the pitfall up clearly and posting it, and the next person saves hours. That is all the open-source spirit is. And contribution is not only code. Documentation, translation, reproducing benchmarks, helping pin down an issue: these matter as much as writing kernels.
+
+The open-source community welcomes people who want to learn the technology and are willing to contribute to it, because everyone starts out not knowing. Who it does not welcome are those who treat open source as a résumé-padding tool. Participating in open source for your résumé is not a problem in itself; nearly everyone's motivation includes some of that. The problem is confusing means and ends, when the goal becomes PR count rather than solving problems.
+
+This lesson closes on three points: respect other people's time, respect the craft, and take responsibility for your own code. Writing code is not like building a bridge, where a collapse brings legal liability. But as fellow engineers, we hope everyone in this course carries an engineer's pride and sense of responsibility, and truly lives out "one for all, all for one" in the open-source community.
+
+Character before craft. Please keep this open-source spirit with you as you move into the code that follows.

--- a/eng/part0/Part0-Deploy-Your-First-SGLang-Server.md
+++ b/eng/part0/Part0-Deploy-Your-First-SGLang-Server.md
@@ -1,0 +1,188 @@
+# Part 0 — Before you learn
+
+## Deploying SGLang on a local GPU
+
+In this lesson you will use SGLang to run Qwen3-0.6B on your own GPU and send your first request. Qwen3-0.6B is the smallest model in the Qwen3 family: about 1.5 GB of weights, runs in 4 GB of VRAM, and serves as our teaching model. Later in the course we will show you how to build your own mini-sglang and serve a model with it.
+(You can also point your coding agent at this lesson and let it run through the steps automatically.)
+
+### Requirements
+
+- NVIDIA GPU with ≥ 4 GB of VRAM. RTX 30/40/50 series cards work out of the box; older cards such as the RTX 20 series or T4 need an extra flag, see the FAQ at the end.
+- Linux or WSL2. Native Windows is not supported. macOS is not supported; if you have no NVIDIA card, see the end of this lesson.
+- NVIDIA driver installed. Verify with:
+
+```bash
+nvidia-smi
+```
+
+If it shows your GPU and the CUDA Version in the top-right corner is ≥ 12.x, you are good. That version number decides which set of install commands to use below. You do not need to install the CUDA Toolkit separately: SGLang's dependencies ship their own CUDA runtime. On WSL2 the driver is installed on the Windows side; nothing extra is needed inside WSL2.
+
+### Python environment
+
+Python ≥ 3.10 is required. We recommend a dedicated environment:
+
+```bash
+conda create -n sglang python=3.12 -y
+conda activate sglang
+```
+
+Without conda, venv works the same:
+
+```bash
+python3 -m venv ~/sglang-env
+source ~/sglang-env/bin/activate
+```
+
+Run every command that follows inside this environment. A new terminal needs to activate it again.
+
+### Installing SGLang
+
+SGLang is built against CUDA 13 by default. Pick the install commands by the CUDA Version shown in the top-right corner of `nvidia-smi`.
+
+**CUDA Version ≥ 13.0**:
+
+```bash
+pip install --upgrade pip
+pip install uv
+uv pip install --prerelease=allow sglang
+```
+
+**CUDA Version 12.x**:
+
+```bash
+pip install --upgrade pip
+pip install uv
+uv pip install --prerelease=allow sglang
+uv pip install --force-reinstall torch==2.13.0 torchaudio==2.11.0 torchvision --index-url https://download.pytorch.org/whl/cu129
+uv pip install --force-reinstall sglang-kernel --index-url https://docs.sglang.ai/whl/cu129/
+uv pip install --force-reinstall sgl-deep-gemm --index-url https://docs.sglang.ai/whl/cu129/ --no-deps
+```
+
+The last three commands swap torch and the kernels for CUDA 12 builds. Alternatively, upgrade the driver to ≥ 580 and use the CUDA 13 commands directly.
+
+Verify:
+
+```bash
+python3 -c "import sglang; print(sglang.__version__)"
+```
+
+If it prints a version number, the install succeeded. Install steps change between releases; if you hit errors, the [official installation docs](https://docs.sglang.io/get_started/install.html) are the source of truth.
+
+### Faster model downloads (users in mainland China)
+
+Model weights are hosted on Hugging Face and download automatically the first time the server starts. Direct downloads from mainland China are slow; pick either of the following.
+
+Use the hf-mirror mirror:
+
+```bash
+export HF_ENDPOINT=https://hf-mirror.com
+```
+
+Or download from ModelScope:
+
+```bash
+uv pip install modelscope
+export SGLANG_USE_MODELSCOPE=true
+```
+
+`export` only affects the current terminal. The terminal that launches the server must have it set, or it has no effect. To make it permanent:
+
+```bash
+echo 'export HF_ENDPOINT=https://hf-mirror.com' >> ~/.bashrc
+```
+
+### Launching the server
+
+```bash
+python3 -m sglang.launch_server --model-path Qwen/Qwen3-0.6B --host 0.0.0.0 --port 30000
+```
+
+The first run downloads about 1.5 GB of weights. The server is up once this line appears in the log:
+
+```
+The server is fired up and ready to roll!
+```
+
+Closing this terminal stops the server, so keep it running. Do the following steps in a new terminal.
+
+Deployment parameters for the whole Qwen3 family across different hardware are in the [SGLang Cookbook](https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3). The defaults are fine for this lesson.
+
+### Sending requests
+
+Check that the server is alive:
+
+```bash
+curl http://localhost:30000/health
+```
+
+Send your first chat request:
+
+```bash
+curl -s http://localhost:30000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "Introduce yourself in one sentence."}],
+    "max_tokens": 512
+  }'
+```
+
+If the returned JSON contains the model's answer, it worked.
+
+SGLang's API is OpenAI-compatible. Calling it from Python needs the openai library (`uv pip install openai`):
+
+```python
+import openai
+
+client = openai.Client(base_url="http://127.0.0.1:30000/v1", api_key="None")
+
+response = client.chat.completions.create(
+    model="Qwen/Qwen3-0.6B",
+    messages=[{"role": "user", "content": "List 3 countries and their capitals."}],
+    max_tokens=512,
+)
+print(response.choices[0].message.content)
+```
+
+Qwen3 emits a `<think>...</think>` reasoning block before its answer by default. This is not a bug. If you do not need the reasoning, disable it in the request:
+
+```python
+response = client.chat.completions.create(
+    model="Qwen/Qwen3-0.6B",
+    messages=[{"role": "user", "content": "List 3 countries and their capitals."}],
+    max_tokens=512,
+    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+)
+```
+
+Or launch the server with `--reasoning-parser qwen3`, which separates the reasoning into the response's `reasoning_content` field.
+
+### FAQ
+
+**OOM (out of memory)**: little VRAM, or the GPU is also driving a desktop. Lower SGLang's share of memory and shorten the context:
+
+```bash
+python3 -m sglang.launch_server --model-path Qwen/Qwen3-0.6B --mem-fraction-static 0.6 --context-length 8192 --port 30000
+```
+
+**RTX 20 series / T4 and other older cards fail to start**: the default attention backend needs a newer architecture. Switch to triton:
+
+```bash
+python3 -m sglang.launch_server --model-path Qwen/Qwen3-0.6B --attention-backend triton --port 30000
+```
+
+**CUDA errors at startup (such as "CUDA driver version is insufficient" / "no kernel image is available")**: the driver is CUDA 12.x but the default CUDA 13 dependencies were installed. Fix: run the three force-reinstall commands from the CUDA 12 part of "Installing SGLang".
+
+**Download hangs**: the usual cause is that `HF_ENDPOINT` / `SGLANG_USE_MODELSCOPE` was not set in the terminal that launched the server.
+
+**address already in use**: the port is taken. Use another port (such as `--port 30001`) and change the port in your request commands to match.
+
+**nvidia-smi not found in WSL2**: the driver has to be installed on the Windows side (download it from NVIDIA's website). After installing, run `wsl --shutdown` in PowerShell to restart WSL.
+
+**Anything else**: post the full command and the full error (as text, not a screenshot) in the course group. Attaching your `nvidia-smi` output and SGLang version speeds up diagnosis a lot.
+
+### No NVIDIA GPU
+
+The course experiments assume an NVIDIA environment. SGLang also supports [AMD Instinct](https://docs.sglang.io/docs/hardware-platforms/amd_gpu), [Intel Xeon CPU](https://docs.sglang.io/docs/hardware-platforms/cpu_server), [Apple Silicon (experimental)](https://docs.sglang.io/docs/hardware-platforms/apple_metal) and other platforms, but later lessons are not guaranteed to work on them, so we do not recommend them for this course.
+
+If you are on a Mac or have no NVIDIA card, rent an entry-level GPU by the hour on a cloud GPU platform such as AutoDL (the cheapest card that runs Qwen3-0.6B is enough). The rented machine is a ready-made Linux environment; start from the "Python environment" section. If the course provides shared compute, we will announce it in the course group.


### PR DESCRIPTION
把 #27 的两个 commit 重新提到 main。#27 当时合进了已经 squash 合并过的 eng-section 分支，内容没有进 main。

- `eng/part0/` 两篇英文翻译：Coding Ethics and Open-Source Spirit、Deploy Your First SGLang Server
- 新增 `README_en.md`；两个 README 顶部各加一个指向另一语言的链接
- 英文站点导航 / 侧边栏 / 首页接到 Part 0

验证：本分支的文件树与 origin/eng-section 完全一致（`git diff origin/eng-section` 为空），本地 `pnpm run build` 通过。