### PR TITLE
Add English placeholder pages for every chapter

### DIFF
--- a/course-material/eng/part1/Chapter1_Introduction_to_LLM.md
+++ b/course-material/eng/part1/Chapter1_Introduction_to_LLM.md
@@ -1,0 +1,3 @@
+# Chapter 1 Introduction to LLM
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part1/Chapter3_Introduction_to_GPU.md
+++ b/course-material/eng/part1/Chapter3_Introduction_to_GPU.md
@@ -1,0 +1,3 @@
+# Chapter 3 Introduction to GPU
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part2/Chapter10_Speculative-Decoding.md
+++ b/course-material/eng/part2/Chapter10_Speculative-Decoding.md
@@ -1,0 +1,3 @@
+# Chapter 10 Speculative Decoding
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part2/Chapter1_mini-sglang-What-an-Inference-Engine-Looks-Like.md
+++ b/course-material/eng/part2/Chapter1_mini-sglang-What-an-Inference-Engine-Looks-Like.md
@@ -1,0 +1,3 @@
+# Chapter 1 mini-sglang, what an inference engine looks like
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part2/Chapter2_Inside-SGLang.md
+++ b/course-material/eng/part2/Chapter2_Inside-SGLang.md
@@ -1,0 +1,3 @@
+# Chapter 2 Inside SGLang: The Path of a Request
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part2/Chapter3_Forward-Pass-and-Generation.md
+++ b/course-material/eng/part2/Chapter3_Forward-Pass-and-Generation.md
@@ -1,0 +1,3 @@
+# Chapter 3 Your First 200 Lines: Forward Pass and Generation
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part2/Chapter4_KV-Cache-Optimization.md
+++ b/course-material/eng/part2/Chapter4_KV-Cache-Optimization.md
@@ -1,0 +1,3 @@
+# Chapter 4 KV Cache: From O(n²) to O(n)
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part2/Chapter5_HTTP-and-Concurrent-Requests.md
+++ b/course-material/eng/part2/Chapter5_HTTP-and-Concurrent-Requests.md
@@ -1,0 +1,3 @@
+# Chapter 5 Serving It: HTTP and Concurrent Requests
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part2/Chapter6_Continuous-Batching-and-the-Scheduler.md
+++ b/course-material/eng/part2/Chapter6_Continuous-Batching-and-the-Scheduler.md
@@ -1,0 +1,3 @@
+# Chapter 6 Continuous Batching and the Scheduler
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part2/Chapter7_Paged-KV-Cache-and-Memory-Management.md
+++ b/course-material/eng/part2/Chapter7_Paged-KV-Cache-and-Memory-Management.md
@@ -1,0 +1,3 @@
+# Chapter 7 Paged KV Cache and Memory Management
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part2/Chapter8_RadixAttention-and-Prefix-Caching.md
+++ b/course-material/eng/part2/Chapter8_RadixAttention-and-Prefix-Caching.md
@@ -1,0 +1,3 @@
+# Chapter 8 RadixAttention and Prefix Caching
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part2/Chapter9_Multi-process-and-Tensor-Parallelism.md
+++ b/course-material/eng/part2/Chapter9_Multi-process-and-Tensor-Parallelism.md
@@ -1,0 +1,3 @@
+# Chapter 9 Multi-process & Tensor Parallelism
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part3/Chapter1_Attention-Backends-and-CUDA-Graph.md
+++ b/course-material/eng/part3/Chapter1_Attention-Backends-and-CUDA-Graph.md
@@ -1,0 +1,3 @@
+# Chapter 1 Attention Backends and CUDA Graph
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part3/Chapter2_Quantization-and-Low-Precision-Inference.md
+++ b/course-material/eng/part3/Chapter2_Quantization-and-Low-Precision-Inference.md
@@ -1,0 +1,3 @@
+# Chapter 2 Quantization and Low-Precision Inference
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part3/Chapter3_Hierarchical-Caching.md
+++ b/course-material/eng/part3/Chapter3_Hierarchical-Caching.md
@@ -1,0 +1,3 @@
+# Chapter 3 Hierarchical Caching
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part3/Chapter4_Scaling-Out.md
+++ b/course-material/eng/part3/Chapter4_Scaling-Out.md
@@ -1,0 +1,3 @@
+# Chapter 4 Scaling Out: DP Attention, EP, PP
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part3/Chapter5_Prefill-Decode-Disaggregation.md
+++ b/course-material/eng/part3/Chapter5_Prefill-Decode-Disaggregation.md
@@ -1,0 +1,3 @@
+# Chapter 5 Prefill-Decode Disaggregation
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part4/Chapter1_Deploying-SGLang-with-the-Cookbook.md
+++ b/course-material/eng/part4/Chapter1_Deploying-SGLang-with-the-Cookbook.md
@@ -1,0 +1,3 @@
+# Chapter 1 Deploying SGLang with the Cookbook
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part4/Chapter2_Profiling-and-Trace-Analysis.md
+++ b/course-material/eng/part4/Chapter2_Profiling-and-Trace-Analysis.md
@@ -1,0 +1,3 @@
+# Chapter 2 Measuring It All: Profiling and Trace Analysis
+
+This chapter is being written. Stay tuned.

--- a/course-material/eng/part4/Chapter3_SGLang-PR-Workflow.md
+++ b/course-material/eng/part4/Chapter3_SGLang-PR-Workflow.md
@@ -1,0 +1,3 @@
+# Chapter 3 SGLang PR Workflow
+
+This chapter is being written. Stay tuned.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -86,10 +86,14 @@ const chSidebar: DefaultTheme.SidebarItem[] = [
 const engNav: DefaultTheme.NavItem[] = [
   { text: 'Home', link: '/eng/' },
   { text: 'Part 0', link: '/eng/part0/Part0-Coding-Ethics-and-Open-Source-Spirit' },
+  { text: 'Part I', link: '/eng/part1/Chapter1_Introduction_to_LLM' },
+  { text: 'Part II', link: '/eng/part2/Chapter1_mini-sglang-What-an-Inference-Engine-Looks-Like' },
+  { text: 'Part III', link: '/eng/part3/Chapter1_Attention-Backends-and-CUDA-Graph' },
+  { text: 'Part IV', link: '/eng/part4/Chapter1_Deploying-SGLang-with-the-Cookbook' },
   { text: 'Community', link: '/eng/community/' },
 ]
 
-// Sections are added here as their English chapters land.
+// Every chapter has a page; untranslated ones are placeholders (see course-material/eng/WRITING_TEMPLATE.md).
 const engSidebar: DefaultTheme.SidebarItem[] = [
   {
     text: 'Part 0 — Before you learn',
@@ -101,9 +105,44 @@ const engSidebar: DefaultTheme.SidebarItem[] = [
   {
     text: 'Part I — Foundations',
     items: [
-      { text: 'Chapter 2 Inference', link: '/eng/part1/Chapter2_Introduction to Inference.md' },
+      { text: 'Chapter 1 Introduction to LLM', link: '/eng/part1/Chapter1_Introduction_to_LLM' },
+      { text: 'Chapter 2 Introduction to Inference', link: '/eng/part1/Chapter2_Introduction to Inference.md' },
+      { text: 'Chapter 3 Introduction to GPU', link: '/eng/part1/Chapter3_Introduction_to_GPU' },
       { text: 'Chapter 4 KV Cache', link: '/eng/part1/Chapter4_KV Cache The Core Data Structure of Inference.md' },
-      { text: 'Chapter 5 — Introduction to Benchmark', link: '/eng/part1/Chapter5_Introduction_to_Benchmark' },
+      { text: 'Chapter 5 Introduction to Benchmark', link: '/eng/part1/Chapter5_Introduction_to_Benchmark' },
+    ],
+  },
+  {
+    text: 'Part II — Build Your Own Mini SGL',
+    items: [
+      { text: 'Chapter 1 mini-sglang Overview', link: '/eng/part2/Chapter1_mini-sglang-What-an-Inference-Engine-Looks-Like' },
+      { text: 'Chapter 2 Inside SGLang', link: '/eng/part2/Chapter2_Inside-SGLang' },
+      { text: 'Chapter 3 Forward Pass and Generation', link: '/eng/part2/Chapter3_Forward-Pass-and-Generation' },
+      { text: 'Chapter 4 KV Cache Optimization', link: '/eng/part2/Chapter4_KV-Cache-Optimization' },
+      { text: 'Chapter 5 HTTP and Concurrent Requests', link: '/eng/part2/Chapter5_HTTP-and-Concurrent-Requests' },
+      { text: 'Chapter 6 Continuous Batching and the Scheduler', link: '/eng/part2/Chapter6_Continuous-Batching-and-the-Scheduler' },
+      { text: 'Chapter 7 Paged KV Cache and Memory Management', link: '/eng/part2/Chapter7_Paged-KV-Cache-and-Memory-Management' },
+      { text: 'Chapter 8 RadixAttention and Prefix Caching', link: '/eng/part2/Chapter8_RadixAttention-and-Prefix-Caching' },
+      { text: 'Chapter 9 Multi-process and Tensor Parallelism', link: '/eng/part2/Chapter9_Multi-process-and-Tensor-Parallelism' },
+      { text: 'Chapter 10 Speculative Decoding', link: '/eng/part2/Chapter10_Speculative-Decoding' },
+    ],
+  },
+  {
+    text: 'Part III — Advanced Inference Technique',
+    items: [
+      { text: 'Chapter 1 Attention Backends and CUDA Graph', link: '/eng/part3/Chapter1_Attention-Backends-and-CUDA-Graph' },
+      { text: 'Chapter 2 Quantization and Low-Precision Inference', link: '/eng/part3/Chapter2_Quantization-and-Low-Precision-Inference' },
+      { text: 'Chapter 3 Hierarchical Caching', link: '/eng/part3/Chapter3_Hierarchical-Caching' },
+      { text: 'Chapter 4 Scaling Out', link: '/eng/part3/Chapter4_Scaling-Out' },
+      { text: 'Chapter 5 Prefill-Decode Disaggregation', link: '/eng/part3/Chapter5_Prefill-Decode-Disaggregation' },
+    ],
+  },
+  {
+    text: 'Part IV — How to Make Contribution to SGLang',
+    items: [
+      { text: 'Chapter 1 Deploying SGLang with the Cookbook', link: '/eng/part4/Chapter1_Deploying-SGLang-with-the-Cookbook' },
+      { text: 'Chapter 2 Profiling and Trace Analysis', link: '/eng/part4/Chapter2_Profiling-and-Trace-Analysis' },
+      { text: 'Chapter 3 SGLang PR Workflow', link: '/eng/part4/Chapter3_SGLang-PR-Workflow' },
     ],
   },
   {


### PR DESCRIPTION
- 照中文版的做法，给英文版每一章建占位页：Part I 第 1、3 章，Part II 1–10 章，Part III 1–5 章，Part IV 1–3 章，共 20 个文件，内容为 `# Chapter N <大纲英文名>` 加一句 stay tuned
- 英文侧栏补齐 Part I–IV 全部章节（`check_site.py` 要求每个章节页都在侧栏里），导航栏加 Part I–IV 入口，与中文侧栏对齐
- Part I 第 1、3 章沿用 PR #3 里的英文文件名 `Chapter1_Introduction_to_LLM.md` / `Chapter3_Introduction_to_GPU.md`，PR #3 合入时直接覆盖内容即可；其余新文件按英文模板用连字符命名

验证：`check_chapters.py --all` 52 个文件，新增文件 0 错误（剩余 4 条是 main 上已有的，#41 在修）；`check_site.py` 0 错误。