### PR TITLE
fix: remove extra spaces around LaTeX inline formulas in chapter 1

### DIFF
--- a/course-material/ch/part1/第1章_LLM入门.md
+++ b/course-material/ch/part1/第1章_LLM入门.md
@@ -159,7 +159,7 @@ $$
 \text{Head}_i = \text{Attention}(Q_i, K_i, V_i) = \text{softmax}\left(\frac{Q_i K_i^T}{\sqrt{d_k}}\right)V_i
 $$
 
-其中 $Q_i, K_i, V_i$ 的形状均为$[batchSize, seqLen, d_k]$，因此 $Q_i K_i^T$ 的形状为 $[batchSize, seqLen, seqLen]$，表示该头内部所有位置两两之间的注意力分数。该头的输出 $\text{Head}_i$ 形状同样为 $[batchSize, seqLen, d_k]$。
+其中 $Q_i, K_i, V_i$ 的形状均为 $[batchSize, seqLen, d_k]$，因此 $Q_i K_i^T$ 的形状为 $[batchSize, seqLen, seqLen]$，表示该头内部所有位置两两之间的注意力分数。该头的输出 $\text{Head}_i$ 形状同样为 $[batchSize, seqLen, d_k]$。
 
 **第三步：拼接与最终线性变换**
 

--- a/course-material/ch/part1/第1章_LLM入门.md
+++ b/course-material/ch/part1/第1章_LLM入门.md
@@ -159,7 +159,7 @@ $$
 \text{Head}_i = \text{Attention}(Q_i, K_i, V_i) = \text{softmax}\left(\frac{Q_i K_i^T}{\sqrt{d_k}}\right)V_i
 $$
 
-其中 $Q_i, K_i, V_i$ 的形状均为$[batchSize, seqLen, d_k]$，因此 $ Q_i K_i^T$ 的形状为 $[batchSize, seqLen, seqLen]$，表示该头内部所有位置两两之间的注意力分数。该头的输出 $\text{Head}_i$ 形状同样为 $[batchSize, seqLen, d_k]$。
+其中 $Q_i, K_i, V_i$ 的形状均为$[batchSize, seqLen, d_k]$，因此 $Q_i K_i^T$ 的形状为 $[batchSize, seqLen, seqLen]$，表示该头内部所有位置两两之间的注意力分数。该头的输出 $\text{Head}_i$ 形状同样为 $[batchSize, seqLen, d_k]$。
 
 **第三步：拼接与最终线性变换**
 


### PR DESCRIPTION
LaTeX formulas in chapter 1 (multi-head attention section) were not rendering correctly:
<img width="762" height="339" alt="image" src="https://github.com/user-attachments/assets/4c1ccfb7-3345-4377-b9aa-108f2d0be9ea" />

After fix:
<img width="818" height="88" alt="image" src="https://github.com/user-attachments/assets/d7c31eb7-e618-4517-bc0b-a67d6b8601a9" />

Changed files:
- `course-material/ch/part1/第1章_LLM入门.md`