### PR TITLE
ENH: Enhance Prefill section with detailed FLOPs estimation and memory flow analysis

### DIFF
--- a/course-material/ch/part1/第2章_推理入门.md
+++ b/course-material/ch/part1/第2章_推理入门.md
@@ -154,27 +154,45 @@ $$P(\text{token}_i \mid \text{token}_1, \text{token}_2, \dots, \text{token}_{i-1
 
 ### 4.2 Prefill
 
-&emsp;&emsp;Prefill 阶段是对当前调度到的 Prompt（可以是单个请求，也可以是多个请求打包成的 batch）进行**一次完整的前向传播**。模型会**并行处理**所有输入 token，**构建并写入初始 KV cache**，同时得到第一个生成 token 的 logits。以  LLaMA-7B 的 Prefill 场景为例：
+&emsp;&emsp;Prefill 阶段会对当前调度到的 Prompt（可以是单个请求，也可以是多个请求组成的 batch）执行**一次完整的前向传播**。模型会**并行处理** Prompt 中的所有输入 token，**构建并写入初始 KV cache**，并计算各位置的 logits。其中，最后一个输入位置的 logits 用于生成第一个输出 token。
 
-- **处理 2 个用户请求**，合计 **N = 3000** 个 token  
-- 模型 config ：层数 $L = 32$，隐藏层维度 $d = 4096$ ，FFN 中间计算维度约 $4d = 16384$ ，注意力机制头数 $\text{heads} = 32$
+以 LLaMA-7B 的 Prefill 场景为例：
 
-**1.单次完整前向处理 1 个批次的 FLOPs 估算**
+- 处理一个长度为 $N=3000$ token 的请求；
+- 模型配置：层数 $L=32$、隐藏层维度 $d=4096$、FFN 中间维度 $d_{\mathrm{ff}}=11008$、注意力头数 $\text{heads}=32$。
+
+**1. 单个长度为 $N$ 的序列，一次完整 Prefill 的 FLOPs 估算**
 
 一次前向传播的主要计算包括：
 
-- **QKV + 输出投影**&emsp;4 个线性层，共 $2 \times 4 \times N d^{2}$ ;
-- **FFN**&emsp;两个线性层升维 + 降维，共 $2 \times 2 \times (4d \times Nd)$ ;
-- **Attention 核心计算** &emsp; $QK^{\top}$ 与 score× $V$   共 $2 \times 2 \times N^{2} d$ .
+- **QKV + 输出投影**：共 4 个线性投影，计算量约为 $2\times 4\times Nd^2 = 8Nd^2$;
+- **FFN（SwiGLU）**：包含 `gate_proj`、`up_proj` 和 `down_proj` 3 个线性投影，计算量约为 $2\times 2\times N^2d = 4N^2d$;
+- **Attention 核心计算**：$QK^\top$ 与 attention score 乘以 $V$，计算量约为 $2\times 2\times N^2d = 4N^2d$。
 
-单层总计 $24 N d^{2} + 4 N^{2} d$ ，整个模型为 $\text{Total FLOPs} \approx L \times \bigl(24 N d^{2} + 4 N^{2} d\bigr)$ ，带入具体数值的每 1 层总计算量表示：
+因此，单层的主要计算量约为
 
-- 线性投影 + FFN 主导项： $24 \times 3000 \times 4096^{2} \approx 1.21 \times 10^{12} \ \mathrm{ FLOPs / 层 }$ ;
-- Attention 项（一次输出 N 个token ）： $4 \times 3000^{2} \times 4096 \approx 1.47 \times 10^{11} \ \mathrm{ FLOPs / 层 }$ .
+$$
+8Nd^2 + 6Ndd_{\mathrm{ff}} + 4N^2d
+$$
 
-&emsp;&emsp;**32 层总计算量 =  32 × (线性投影 + FFN 项 + Attention 项) ≈ 43.4 TFLOPs**，换算成更直观的单位——大约相当于一台 A100 G40（312 TFLOPS 峰值）理论全力计算约 **0.14 s** 的工作量，但是实际无法达到 100% 使用率。
+整个模型的计算量约为
 
+$$
+\text{Total FLOPs} \approx L\left(8Nd^2+6Ndd_{\mathrm{ff}}+4N^2d\right)
+$$
 
+代入 $N=3000$、$d=4096$ 和 $d_{\mathrm{ff}}=11008$：
+
+- **线性投影与 FFN**：$1.214\times10^{12}\ \mathrm{FLOPs/层}$；
+- **Attention 核心计算**：$1.475\times10^{11}\ \mathrm{FLOPs/层}$。
+
+32 层的总计算量约为
+
+$$
+32\times\left(1.214\times10^{12}+1.475\times10^{11}\right) \approx43.6\ \mathrm{TFLOPs}
+$$
+
+这大约相当于一台 A100 40GB（FP16/BF16 Tensor Core 峰值约为 $312\ \mathrm{TFLOPS}$）以理论峰值持续计算 $0.14\ \mathrm{s}$ 的工作量。实际执行时间会更长，因为硬件通常无法始终达到理论峰值。
 
 **2. 不同 Prompt 长度的对比**
 
@@ -185,14 +203,12 @@ $$P(\text{token}_i \mid \text{token}_1, \text{token}_2, \dots, \text{token}_{i-1
 
 在中等长度（几千 token）时，计算量基本随 $N$ **近似线性增长**；当 Prompt 变得很长时，Attention 的二次项会让计算量加速上涨。
 
-
-
 **3. 内存流量**
 
-LLaMA-7B 模型权重为 FP16，约占用 14 GB。在 Prefill 阶段，内存流量主要包括：
+LLaMA-7B 的 FP16 模型权重约占 14 GB。作为一个简化估算，Prefill 阶段的主要显存流量包括：
 
 - **模型权重读取**：14 GB
-- **KV cache 写入**，每个 token（占用空间大小为 2 byte）的 KV cache 大小为 $2 \text{ (KV)} \times 32 \text{层} \times 4096 \times 2 \ \mathrm{byte} \approx 0.5 \text{MB}$ 。处理 3000 个输入 token，需写入约 **1.5 GB** 
+- **KV cache 写入**：每个 token（占用空间大小为 2 byte）的 KV cache 大小为 $2 \text{ (KV)} \times 32 \text{层} \times 4096 \times 2 \ \mathrm{byte} \approx 0.5 \text{MB}$ 。处理 3000 个输入 token，需写入约 **1.5 GB** 
 - **激活值**：相对较小，可忽略
 
 因此，Prefill 阶段的总内存流量约为 **15-16 GB**。结合前面计算的 43.4 TFLOPs，这意味着平均每从显存读取 1 字节的数据，会执行数千次浮点运算。


### PR DESCRIPTION
## Summary

This PR improves the technical accuracy of the Prefill FLOPs and memory-traffic analysis in Section 4.2.

## Changes

- Changed the example from two batched requests to one 3,000-token sequence so that the $N^2$ attention calculation is consistent.
- Corrected the LLaMA-7B FFN description:
  - LLaMA uses SwiGLU with `gate_proj`, `up_proj`, and `down_proj`.
  - Replaced the two-projection approximation with three projections.
  - Replaced $4d$ with the actual intermediate dimension $d_{\mathrm{ff}}=11008$.
- Updated the per-layer and total Prefill FLOPs formulas and numerical results.
- Clarified that Prefill computes logits for all input positions, while the logits at the final position are used to generate the first output token.
- Fixed minor terminology and formatting issues, including the A100 40GB model name.

cc @1iyouzhen 
