### PR TITLE
docs: add Discord reader community link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ No. The course starts from inference concepts. Low-level topics such as attentio
 </details>
 
 
+## 💬 Reader Community
+
+Join the zero-to-sglang reader community to learn together, ask questions, and share ideas: [Join our Discord community](https://discord.gg/4CVfSBgCuu)
+
 ## 👥 Contributors
 
 


### PR DESCRIPTION
Adds a Reader Community section to the English README so readers can join the Discord community to ask questions and share ideas. The invitation text and link appear on the same line, with the section placed between FAQ and Contributors to match the Chinese README.

Validation: verified the supplied Discord URL and passed git diff --check. Only README.md changed.
